### PR TITLE
Agrega mejora en codigo de JS para consumo de API cuando el payload es un array

### DIFF
--- a/JavaScript/api-client/Client.js
+++ b/JavaScript/api-client/Client.js
@@ -59,6 +59,7 @@ class Client {
     console.log(`Headers: [${JSON.stringify(headers)}]`)
     const success_response_200 = 200
     const success_response_201 = 201
+    const http_verb_get = "GET"
     const b_trace_header = "b-trace"
     const location_header = "location"
     let responsePayload = ""
@@ -93,7 +94,7 @@ class Client {
             reject(error);
           } else {
             console.log(`Response: ${response.statusCode} ${response.statusMessage}`)
-            if (payloadEncryption && response.statusCode == success_response_200) {
+            if (payloadEncryption && response.statusCode == success_response_200 && httpVerb == http_verb_get) {
               const responseData = typeof body === 'string' ? JSON.parse(body) : body;
                await  securityManager.decryptAndVerifySignPayload(responseData.data, process.env.SUBSCRIPTION_B_APPLICATION, clientPrivateKey, process.env.JWE_SERVER_PUBLICKEY)
               .then((decryptedPayload) => {

--- a/JavaScript/api-client/package-lock.json
+++ b/JavaScript/api-client/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "api-consumer",
+  "name": "api-client",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "api-consumer",
+      "name": "api-client",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/JavaScript/api-client/util/security-manager.js
+++ b/JavaScript/api-client/util/security-manager.js
@@ -76,8 +76,8 @@ const JWE_ALGORITHM = 'RSA-OAEP-256'
 
         const jwkPrivateRSA = rsaPemToJwk(clientPrivateKey, { kid: bApplication }, 'private');
         const privateKey = await jose.importJWK(jwkPrivateRSA, JWT_ALGORITHM);
-        
-        const signedPayload = await new jose.SignJWT(JSON.parse(payload))
+
+        const signedPayload = await new jose.CompactSign(Buffer.from(payload))
             .setProtectedHeader({ alg: JWT_ALGORITHM, kid: bApplication })
             .sign(privateKey);
 


### PR DESCRIPTION
Se agrega solución en JS para permitir en las APIS el envío de payload cuando solo sea un array y no un objeto JSON.
Ademas se realiza el cambio para cuando no sea un GET, no intente desencriptar la respuesta.